### PR TITLE
feature #14 : Carousel 뷰 구현

### DIFF
--- a/Tyler/Tyler.xcodeproj/project.pbxproj
+++ b/Tyler/Tyler.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		F013F41D2ACF1E4D00423AFF /* RoundCornerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013F41C2ACF1E4D00423AFF /* RoundCornerView.swift */; };
 		F05A8E632AD5BAE600898431 /* Carousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05A8E622AD5BAE600898431 /* Carousel.swift */; };
 		F0AF3C412AD5BD6600F4F69D /* CarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AF3C402AD5BD6600F4F69D /* CarouselView.swift */; };
+		F0AF3C472AD5E27200F4F69D /* CarouselView_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AF3C462AD5E27200F4F69D /* CarouselView_iOS.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +42,7 @@
 		F013F41C2ACF1E4D00423AFF /* RoundCornerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundCornerView.swift; sourceTree = "<group>"; };
 		F05A8E622AD5BAE600898431 /* Carousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Carousel.swift; sourceTree = "<group>"; };
 		F0AF3C402AD5BD6600F4F69D /* CarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselView.swift; sourceTree = "<group>"; };
+		F0AF3C462AD5E27200F4F69D /* CarouselView_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselView_iOS.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,6 +138,7 @@
 			children = (
 				F05A8E622AD5BAE600898431 /* Carousel.swift */,
 				F0AF3C402AD5BD6600F4F69D /* CarouselView.swift */,
+				F0AF3C462AD5E27200F4F69D /* CarouselView_iOS.swift */,
 			);
 			path = Carousel;
 			sourceTree = "<group>";
@@ -218,6 +221,7 @@
 				F001E6562ACF23E60002F665 /* HeroAnimationView.swift in Sources */,
 				F0AF3C412AD5BD6600F4F69D /* CarouselView.swift in Sources */,
 				F013F3BC2ACE96FB00423AFF /* TylerApp.swift in Sources */,
+				F0AF3C472AD5E27200F4F69D /* CarouselView_iOS.swift in Sources */,
 				F001E65D2ACF59CF0002F665 /* Animations.swift in Sources */,
 				F013F4182ACF025900423AFF /* RoundCorner.swift in Sources */,
 				F001E6582ACF52660002F665 /* CardView.swift in Sources */,

--- a/Tyler/Tyler.xcodeproj/project.pbxproj
+++ b/Tyler/Tyler.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		F013F4182ACF025900423AFF /* RoundCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013F4172ACF025900423AFF /* RoundCorner.swift */; };
 		F013F41A2ACF054F00423AFF /* Tyler.docc in Sources */ = {isa = PBXBuildFile; fileRef = F013F4192ACF054F00423AFF /* Tyler.docc */; };
 		F013F41D2ACF1E4D00423AFF /* RoundCornerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013F41C2ACF1E4D00423AFF /* RoundCornerView.swift */; };
+		F05A8E632AD5BAE600898431 /* Carousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05A8E622AD5BAE600898431 /* Carousel.swift */; };
+		F0AF3C412AD5BD6600F4F69D /* CarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AF3C402AD5BD6600F4F69D /* CarouselView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -37,6 +39,8 @@
 		F013F4172ACF025900423AFF /* RoundCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundCorner.swift; sourceTree = "<group>"; };
 		F013F4192ACF054F00423AFF /* Tyler.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Tyler.docc; sourceTree = "<group>"; };
 		F013F41C2ACF1E4D00423AFF /* RoundCornerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundCornerView.swift; sourceTree = "<group>"; };
+		F05A8E622AD5BAE600898431 /* Carousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Carousel.swift; sourceTree = "<group>"; };
+		F0AF3C402AD5BD6600F4F69D /* CarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +103,7 @@
 			children = (
 				F013F3BB2ACE96FB00423AFF /* TylerApp.swift */,
 				F013F3BD2ACE96FB00423AFF /* ContentView.swift */,
+				F05A8E5F2AD5BABA00898431 /* Carousel */,
 				F001E6542ACF23D60002F665 /* HeroAnimation */,
 				F013F41B2ACF1E3B00423AFF /* RoundCorner */,
 				F001E6602AD0530F0002F665 /* ScrollViewOffset */,
@@ -124,6 +129,15 @@
 				F013F4172ACF025900423AFF /* RoundCorner.swift */,
 			);
 			path = RoundCorner;
+			sourceTree = "<group>";
+		};
+		F05A8E5F2AD5BABA00898431 /* Carousel */ = {
+			isa = PBXGroup;
+			children = (
+				F05A8E622AD5BAE600898431 /* Carousel.swift */,
+				F0AF3C402AD5BD6600F4F69D /* CarouselView.swift */,
+			);
+			path = Carousel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -198,9 +212,11 @@
 			files = (
 				F013F3BE2ACE96FB00423AFF /* ContentView.swift in Sources */,
 				F013F41A2ACF054F00423AFF /* Tyler.docc in Sources */,
+				F05A8E632AD5BAE600898431 /* Carousel.swift in Sources */,
 				F001E65A2ACF53F80002F665 /* CardDetailView.swift in Sources */,
 				F001E65F2ACF87DA0002F665 /* ButtonStyles.swift in Sources */,
 				F001E6562ACF23E60002F665 /* HeroAnimationView.swift in Sources */,
+				F0AF3C412AD5BD6600F4F69D /* CarouselView.swift in Sources */,
 				F013F3BC2ACE96FB00423AFF /* TylerApp.swift in Sources */,
 				F001E65D2ACF59CF0002F665 /* Animations.swift in Sources */,
 				F013F4182ACF025900423AFF /* RoundCorner.swift in Sources */,

--- a/Tyler/Tyler/Carousel/Carousel.swift
+++ b/Tyler/Tyler/Carousel/Carousel.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// Description
 struct Carousel<Content: View>: View {
     typealias PageIndex = Int
     
@@ -22,27 +23,29 @@ struct Carousel<Content: View>: View {
         pageCount: Int,
         edgeSpace: CGFloat,
         spacing: CGFloat,
-        currentIndex: Binding<Int>, // currentIndex를 Binding으로 받아옴
+        currentIndex: Binding<Int>,
         @ViewBuilder content: @escaping (PageIndex) -> Content
     ) {
         self.pageCount = pageCount
         self.edgeSpace = edgeSpace
         self.spacing = spacing
-        self._currentIndex = currentIndex // Binding으로 currentIndex 연결
+        self._currentIndex = currentIndex
         self.content = content
     }
     
     var body: some View {
         GeometryReader { proxy in
             let baseOffset = spacing + edgeSpace
+            let pageHeight = proxy.size.height
             let pageWidth = proxy.size.width - (edgeSpace + spacing) * 2
             let offsetX = baseOffset + CGFloat(currentIndex) * -pageWidth + CGFloat(currentIndex) * -spacing + dragOffset
             
             HStack(spacing: spacing) {
                 ForEach(0..<pageCount, id: \.self) { pageIndex in
+                    let scale = calculateScale(pageIndex: pageIndex, pageWidth: pageWidth)
                     self.content(pageIndex)
-                        .frame(width: pageWidth, height: proxy.size.height)
-                        .scaleEffect(calculateScale(pageIndex: pageIndex, pageWidth: pageWidth)) // calculateScale 함수에 pageWidth를 전달
+                        .frame(width: pageWidth, height: pageHeight)
+                        .scaleEffect(scale)
                 }
                 .contentShape(Rectangle())
             }

--- a/Tyler/Tyler/Carousel/Carousel.swift
+++ b/Tyler/Tyler/Carousel/Carousel.swift
@@ -42,15 +42,15 @@ struct Carousel<Content: View>: View {
                 ForEach(0..<pageCount, id: \.self) { pageIndex in
                     self.content(pageIndex)
                         .frame(width: pageWidth, height: proxy.size.height)
-                        .scaleEffect(pageIndex == currentIndex ? 1 : 0.95)
+                        .scaleEffect(calculateScale(pageIndex: pageIndex, pageWidth: pageWidth)) // calculateScale 함수에 pageWidth를 전달
                 }
                 .contentShape(Rectangle())
             }
             .offset(x: offsetX)
             .gesture(
                 DragGesture()
-                    .updating($dragOffset) { value, out, _ in
-                        out = value.translation.width
+                    .updating($dragOffset) { value, dragOffset, _ in
+                        dragOffset = value.translation.width
                     }
                     .onEnded { value in
                         let offsetX = value.translation.width
@@ -62,6 +62,24 @@ struct Carousel<Content: View>: View {
             )
             .animation(.spring, value: dragOffset)
         }
+    }
+    
+    // Scale Animation
+    private func calculateScale(pageIndex: Int, pageWidth: CGFloat) -> CGFloat {
+        let minScale: CGFloat = 0.9
+        let maxScale: CGFloat = 1.0
+        let distanceToCurrent = abs(pageIndex - currentIndex)
+        let dragDistance = abs(dragOffset)
+        
+        var scale = maxScale
+        
+        if distanceToCurrent > 0 {
+            scale = minScale + dragDistance / pageWidth * (maxScale - minScale)
+        } else {
+            scale = maxScale - dragDistance / pageWidth * (maxScale - minScale)
+        }
+        
+        return scale
     }
 }
 

--- a/Tyler/Tyler/Carousel/Carousel.swift
+++ b/Tyler/Tyler/Carousel/Carousel.swift
@@ -1,0 +1,70 @@
+//
+//  Carousel.swift
+//  Tyler
+//
+//  Created by Hyunjun Kim on 10/11/23.
+//
+
+import SwiftUI
+
+struct Carousel<Content: View>: View {
+    typealias PageIndex = Int
+    
+    let pageCount: Int
+    let edgeSpace: CGFloat
+    let spacing: CGFloat
+    let content: (PageIndex) -> Content
+    
+    @GestureState var dragOffset: CGFloat = 0
+    @Binding var currentIndex: Int
+    
+    init(
+        pageCount: Int,
+        edgeSpace: CGFloat,
+        spacing: CGFloat,
+        currentIndex: Binding<Int>, // currentIndex를 Binding으로 받아옴
+        @ViewBuilder content: @escaping (PageIndex) -> Content
+    ) {
+        self.pageCount = pageCount
+        self.edgeSpace = edgeSpace
+        self.spacing = spacing
+        self._currentIndex = currentIndex // Binding으로 currentIndex 연결
+        self.content = content
+    }
+    
+    var body: some View {
+        GeometryReader { proxy in
+            let baseOffset = spacing + edgeSpace
+            let pageWidth = proxy.size.width - (edgeSpace + spacing) * 2
+            let offsetX = baseOffset + CGFloat(currentIndex) * -pageWidth + CGFloat(currentIndex) * -spacing + dragOffset
+            
+            HStack(spacing: spacing) {
+                ForEach(0..<pageCount, id: \.self) { pageIndex in
+                    self.content(pageIndex)
+                        .frame(width: pageWidth, height: proxy.size.height)
+                        .scaleEffect(pageIndex == currentIndex ? 1 : 0.95)
+                }
+                .contentShape(Rectangle())
+            }
+            .offset(x: offsetX)
+            .gesture(
+                DragGesture()
+                    .updating($dragOffset) { value, out, _ in
+                        out = value.translation.width
+                    }
+                    .onEnded { value in
+                        let offsetX = value.translation.width
+                        let progress = -offsetX / pageWidth
+                        let increment = Int(progress.rounded())
+                        
+                        currentIndex = max(min(currentIndex + increment, pageCount - 1), 0)
+                    }
+            )
+            .animation(.spring, value: dragOffset)
+        }
+    }
+}
+
+#Preview {
+    CarouselView()
+}

--- a/Tyler/Tyler/Carousel/CarouselView.swift
+++ b/Tyler/Tyler/Carousel/CarouselView.swift
@@ -14,7 +14,7 @@ struct CarouselView: View {
     
     var body: some View {
         ScrollView {
-            Carousel(pageCount: pageCount, edgeSpace: 30, spacing: 10, currentIndex: $currentIndex) { pageIndex in
+            Carousel(pageCount: pageCount, edgeSpace: 30, spacing: 5, currentIndex: $currentIndex) { pageIndex in
                 Rectangle()
                     .foregroundStyle(.green)
                     .frame(height: 450)

--- a/Tyler/Tyler/Carousel/CarouselView.swift
+++ b/Tyler/Tyler/Carousel/CarouselView.swift
@@ -1,0 +1,43 @@
+//
+//  CarouselView.swift
+//  Tyler
+//
+//  Created by Hyunjun Kim on 10/11/23.
+//
+
+import SwiftUI
+
+struct CarouselView: View {
+    
+    let pageCount = 4
+    @State var currentIndex = 0
+    
+    var body: some View {
+        ScrollView {
+            Carousel(pageCount: pageCount, edgeSpace: 30, spacing: 10, currentIndex: $currentIndex) { pageIndex in
+                Rectangle()
+                    .foregroundStyle(.green)
+                    .frame(height: 450)
+                    .roundedCorner(radius: 40, corners: [.topRight, .bottomLeft, .bottomRight])
+                    .overlay {
+                        Text("\(pageIndex)")
+                    }
+            }
+            .frame(height: 500)
+            HStack {
+                ForEach(0..<pageCount, id: \.self) { i in
+                    Circle()
+                        .frame(width: 10)
+                        .foregroundStyle(currentIndex == i ? .green : .gray)
+                        .animation(.spring, value: currentIndex)
+                }
+            }
+            .padding(.bottom)
+            Text("currentIndex : \(currentIndex)")
+        }
+    }
+}
+
+#Preview {
+    CarouselView()
+}

--- a/Tyler/Tyler/Carousel/CarouselView.swift
+++ b/Tyler/Tyler/Carousel/CarouselView.swift
@@ -10,11 +10,13 @@ import SwiftUI
 struct CarouselView: View {
     
     let pageCount = 4
+    let edgeSpace: CGFloat = 30
+    let spacing: CGFloat = 5
     @State var currentIndex = 0
     
     var body: some View {
         ScrollView {
-            Carousel(pageCount: pageCount, edgeSpace: 30, spacing: 5, currentIndex: $currentIndex) { pageIndex in
+            Carousel(pageCount: pageCount, edgeSpace: edgeSpace, spacing: spacing, currentIndex: $currentIndex) { pageIndex in
                 Rectangle()
                     .foregroundStyle(.green)
                     .frame(height: 450)
@@ -24,6 +26,7 @@ struct CarouselView: View {
                     }
             }
             .frame(height: 500)
+            
             HStack {
                 ForEach(0..<pageCount, id: \.self) { i in
                     Circle()

--- a/Tyler/Tyler/Carousel/CarouselView_iOS.swift
+++ b/Tyler/Tyler/Carousel/CarouselView_iOS.swift
@@ -1,0 +1,38 @@
+//
+//  CarouselView_iOS.swift
+//  Tyler
+//
+//  Created by Hyunjun Kim on 10/11/23.
+//
+
+import SwiftUI
+
+@available(iOS 17.0, *)
+struct CarouselView_iOS: View {
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack {
+                ForEach(0..<5) {_ in
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .frame(width: 300, height: 400)
+                        .foregroundStyle(.purple)
+                        .containerRelativeFrame(.horizontal)
+                        .scrollTransition(.animated, axis: .horizontal) { content, phase in
+                            content
+                                .opacity(phase.isIdentity ? 1.0 : 0.9)
+                                .scaleEffect(phase.isIdentity ? 1.0 : 0.9)
+                        }
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .contentMargins(.horizontal, 50)
+        .scrollTargetBehavior(.viewAligned)
+        .scrollIndicators(.never)
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    CarouselView_iOS()
+}

--- a/Tyler/Tyler/ContentView.swift
+++ b/Tyler/Tyler/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        HeroAnimationView()
+        CarouselView()
     }
 }
 


### PR DESCRIPTION
## 📌 Summary
- #14 
- Carousel 뷰를 구현했습니다.
- 추가 Carousel 페이지 전환시 애니메이션 추가했습니다.
   - 현재 페이지일때 카드가 커집니다.
   - 페이지 전환시 현재카드는 작아지고 다음카드는 커집니다.
- Carousel 뷰 indicator 구현
   - 현재 페이지 임을 확인 할 수 있는 indicator 구현하였습니다. 

<br>

## ✨ Description
## 기존 Carousel 구현
### 사용 예
```swift
Carousel(pageCount: pageCount, edgeSpace: edgeSpace, spacing: spacing, currentIndex: $currentIndex) { pageIndex in
  // 넣을 뷰 
  // pageIndex 를 받아올 수 있습니다.
}
.frame(height: 500)
```
### Carousel 상세
- `DragGesture` 사용했습니다.
```swift
        // Carousel.swift 파일
        ...
        GeometryReader { proxy in
            let baseOffset = spacing + edgeSpace
            let pageHeight = proxy.size.height
            let pageWidth = proxy.size.width - (edgeSpace + spacing) * 2
            let offsetX = baseOffset + CGFloat(currentIndex) * -pageWidth + CGFloat(currentIndex) * -spacing + dragOffset
            
            HStack(spacing: spacing) {
                ForEach(0..<pageCount, id: \.self) { pageIndex in
                    let scale = calculateScale(pageIndex: pageIndex, pageWidth: pageWidth)
                    self.content(pageIndex)
                        .frame(width: pageWidth, height: pageHeight)
                        .scaleEffect(scale)
                }
                .contentShape(Rectangle())
            }
            .offset(x: offsetX)
            .gesture(
                DragGesture()
                    .updating($dragOffset) { value, dragOffset, _ in
                        dragOffset = value.translation.width
                    }
                    .onEnded { value in
                        let offsetX = value.translation.width
                        let progress = -offsetX / pageWidth
                        let increment = Int(progress.rounded())
                        
                        currentIndex = max(min(currentIndex + increment, pageCount - 1), 0)
                    }
            )
            .animation(.spring, value: dragOffset)
        }
        ...
```

### 사용하는 상수, 변수
- `let pageCount` : 전체 페이지 개수
- `let edgeSpace` : 양쪽 끝의 Padding
- `let spacing` : 페이지 마다 Padding
- `@Binding currentIndex` : 현재 페이지 위치를 가져옵니다.

## iOS 17.0 이후 Carousel 구현
- iOS 17.0 버전 이후부터는 ScrollView 에 많은 것들이 추가되었습니다.
- 아래와 같이 ScrollView 에 간단한 추가 설정으로 캐러셀 구현이 가능합니다! **아래 캡쳐 참고**

```swift
        ScrollView(.horizontal) {
            HStack {
                ForEach(0..<5) {_ in
                    RoundedRectangle(cornerRadius: 20, style: .continuous)
                        .frame(width: 300, height: 400)
                        .foregroundStyle(.purple)
                        .containerRelativeFrame(.horizontal)
                        .scrollTransition(.animated, axis: .horizontal) { content, phase in
                            content
                                .opacity(phase.isIdentity ? 1.0 : 0.9)
                                .scaleEffect(phase.isIdentity ? 1.0 : 0.9)
                        }
                }
            }
            .scrollTargetLayout()
        }
        .contentMargins(.horizontal, 50)
        .scrollTargetBehavior(.viewAligned)
        .scrollIndicators(.never)
```
<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|비고|
|:--:|:--:|:--:|
|기존 캐러셀 구현|<img src = "https://github.com/BostonGosari/Baseline/assets/120548537/a6011763-4167-4242-b688-0c461aba946c" width ="250">|iOS 17.0 버전 이하|
|ScrollView 를 활용한 캐러셀|<img src = "https://github.com/BostonGosari/Baseline/assets/120548537/5c0d7f11-57d2-4b31-b799-bd9fc46e0e92" width ="250">|iOS 17.0 버전 이후|


